### PR TITLE
Implemented FromArray.skip

### DIFF
--- a/lib/fromarray.rb
+++ b/lib/fromarray.rb
@@ -29,6 +29,18 @@ class FromArray
     @array = array
   end
 
+  # Skip the first n elements of the stream.
+  def skip(count)
+    raise ArgumentError, 'count has to be positive' unless count.positive?
+
+    skipped = [];
+    @array.each_with_index do |val, index|
+      skipped.push(val) unless index + 1 <= count
+    end
+    @array = skipped
+    self
+  end
+
   # Collect the stream's data into an array and return it.
   def collect
     @array.dup

--- a/test/fromarray_test.rb
+++ b/test/fromarray_test.rb
@@ -63,6 +63,15 @@ class FromArrayTest < Minitest::Test
     end
   end
 
+  # FromArray returns self after skipping some elements.
+  def test_skip_returns_self
+    stream = FromArray.new([1, 2, 3])
+    assert(
+      stream.skip(1).equal?(stream),
+      'Method skip should return the modified stream'
+    )
+  end
+
   # FromArray can skip the first element.
   def test_skip_first_element
     stream = FromArray.new([1, 2, 3])
@@ -78,7 +87,7 @@ class FromArrayTest < Minitest::Test
     stream = FromArray.new([1, 2, 3])
     collected = stream.skip(2).collect
     assert(
-       collected == [3],
+      collected == [3],
       'Expected ' + [3].to_s + ' but got ' + collected.to_s
     )
   end

--- a/test/fromarray_test.rb
+++ b/test/fromarray_test.rb
@@ -49,4 +49,59 @@ class FromArrayTest < Minitest::Test
     )
   end
 
+  # FromArray raises ArgumentError if the given count to skip
+  # is <=0
+  def test_skip_argument_error_count_negative
+    stream = FromArray.new([1, 2, 3])
+    begin
+      stream.skip(-1)
+    rescue ArgumentError => e
+      assert(
+        e.message == 'count has to be positive',
+        'Unexpected ArgumentError message!'
+      )
+    end
+  end
+
+  # FromArray can skip the first element.
+  def test_skip_first_element
+    stream = FromArray.new([1, 2, 3])
+    collected = stream.skip(1).collect
+    assert(
+      collected == [2, 3],
+      'Expected ' + [2, 3].to_s + ' but got ' + collected.to_s
+    )
+  end
+
+  # FromArray can skip more than 1 element.
+  def test_skip_more_elements
+    stream = FromArray.new([1, 2, 3])
+    collected = stream.skip(2).collect
+    assert(
+       collected == [3],
+      'Expected ' + [3].to_s + ' but got ' + collected.to_s
+    )
+  end
+
+  # FromArray can skip all the elements.
+  def test_skips_all_elements
+    stream = FromArray.new([1, 2, 3])
+    collected = stream.skip(3).collect
+    assert(
+      collected == [],
+      'Expected ' + [].to_s + ' but got ' + collected.to_s
+    )
+  end
+
+  # FromArray can skip all the elements because the given
+  # count is greater than the stream's size.
+  def test_skips_all_elements_count_gt_size
+    stream = FromArray.new([1, 2, 3])
+    collected = stream.skip(4).collect
+    assert(
+      collected == [],
+      'Expected ' + [].to_s + ' but got ' + collected.to_s
+    )
+  end
+
 end


### PR DESCRIPTION
Fixes #6 
Implemented and unit tested method ``skip(count)`` which ignores the first ``count`` elements of the stream. It also throws ``ArgumentError`` if ``count`` is negative of zero.

Added unit tests.