### PR TITLE
#14 skip() doesn't mutate the instance

### DIFF
--- a/lib/fromarray.rb
+++ b/lib/fromarray.rb
@@ -24,6 +24,7 @@
 
 module Stream
   # A stream implemented based on an Array.
+  # This class is immutable and thread-safe.
   # Author:: Mihai Andronache (amihaiemil@gmail.com)
   class FromArray
     def initialize(array)
@@ -38,8 +39,7 @@ module Stream
       @array.each_with_index do |val, index|
         skipped.push(val) unless index + 1 <= count
       end
-      @array = skipped
-      self
+      FromArray.new(skipped)
     end
 
     # Collect the stream's data into an array and return it.

--- a/test/fromarray_test.rb
+++ b/test/fromarray_test.rb
@@ -68,8 +68,8 @@ module Stream
     def test_skip_returns_self
       stream = FromArray.new([1, 2, 3])
       assert(
-        stream.skip(1).equal?(stream),
-        'Method skip should return the modified stream'
+        !stream.skip(1).equal?(stream),
+        'Method skip should return a new instance of the modified stream'
       )
     end
 


### PR DESCRIPTION
Fixes #14
Class ``FromArray`` should always be immutable and thread-safe.